### PR TITLE
Add WebSocket Secure (WSS) connection support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,13 +17,23 @@ Integrates Heatmiser Neo heating system with Indigo home automation via the Neoh
 
 ### Communication Protocol
 
-The plugin communicates directly with a **Neohub** device using TCP sockets:
-- **Port**: 4242
-- **Protocol**: JSON over TCP with null terminator (`\0`)
+The plugin supports two connection modes to the **Neohub** device:
+
+**WSS — Secure WebSocket (default, recommended):**
+- **Port**: 4243 (TLS, self-signed cert)
+- **Protocol**: Two-layer JSON envelope over WebSocket. Outer message has `message_type` + `message` fields; inner payload contains API token and `COMMANDS` array with `COMMAND`/`COMMANDID` pairs.
+- **Authentication**: API token (generated in Heatmiser Neo App → Settings → Api Access → Tokens)
+- **Connection**: Persistent WebSocket, thread-safe via `_wss_lock`. Automatically reconnects on failure.
+- **Timeout**: 8 seconds for connection, 10 seconds for response
+
+**Legacy TCP (port 4242):**
+- **Port**: 4242 (unencrypted, no auth)
+- **Protocol**: JSON over TCP with null terminator (`\0`). Opens a new socket per command.
 - **Timeout**: 8 seconds for socket operations
+
 - **IP Address**: Configurable via plugin preferences (default: 192.168.0.1)
 
-All commands are sent as JSON objects wrapped in curly braces: `{"COMMAND":value}`
+All commands are sent as JSON objects: `{"COMMAND":value}`. The WSS path wraps them in the token-authenticated envelope; the TCP path sends them directly with a null terminator.
 
 ### Concurrent Thread Architecture
 
@@ -90,11 +100,14 @@ Heatmiser modes are mapped to Indigo HVAC modes:
 
 ## Plugin Configuration
 
-**PluginConfig.xml** defines three settings:
+**PluginConfig.xml** defines these settings:
 
 1. **neohubIP**: IP address of Neohub (default: 192.168.0.1)
-2. **timeSync**: If true, sync Neohub time with Indigo daily; if false, use NTP
-3. **logComms**: If true, log all socket communications to Indigo Event Log
+2. **connectionMode**: `wss` (default) or `tcp` — selects WSS port 4243 or legacy TCP port 4242
+3. **neohubToken**: API token for WSS authentication (only visible when connectionMode is `wss`)
+4. **neohubGen2**: Gen 2 API toggle (only visible when connectionMode is `tcp`; forced `True` for WSS)
+5. **timeSync**: If true, sync Neohub time with Indigo daily; if false, use NTP
+6. **logComms**: If true, log all communications to Indigo Event Log (token is redacted in WSS logs)
 
 ## Available Actions
 
@@ -111,16 +124,19 @@ Defined in [Actions.xml](HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/Action
 
 ### Error Handling Strategy
 
-The plugin uses error counters to avoid log spam ([plugin.py:44-45](HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/plugin.py#L44-L45)):
-- `connectErrorCount`: Only logs socket connection errors after 3 failures
-- `sendErrorCount`: Only logs socket send errors after 3 failures
-- Counters reset on successful communication
+The plugin uses error counters to avoid log spam:
+- `connectErrorCount` / `sendErrorCount`: Track consecutive failures per transport
+- **WSS path**: Logs the first 3 errors, then every 10th failure. Counters reset on success.
+- **TCP path**: Logs only on the 3rd consecutive failure. `sendErrorCount` resets after logging.
+- Both counters reset to 0 on any successful command.
 
-### Multi-Packet Response Handling
+### Multi-Packet Response Handling (TCP only)
 
-Some commands (INFO, ENGINEERS_DATA) return large JSON responses that may arrive in multiple TCP packets. The plugin handles this by checking for complete JSON markers:
-- `INFO` command: Waits for `}]}` at end of response
-- `ENGINEERS_DATA`: Waits for `}}` at end of response
+On the legacy TCP path, some commands (INFO/GET_LIVE_DATA, ENGINEERS_DATA/GET_ENGINEERS) return large JSON responses that may arrive in multiple TCP packets. The plugin handles this by checking for complete JSON markers:
+- `INFO`/`GET_LIVE_DATA` command: Waits for `}]}` at end of response
+- `ENGINEERS_DATA`/`GET_ENGINEERS`: Waits for `}}` at end of response
+
+The WSS path does not need this — WebSocket messages are framed at the protocol level.
 
 ### JSON Parsing Resilience
 
@@ -176,7 +192,7 @@ If invalid names are detected, the plugin logs an error and you must rename the 
 Heatmiser Neo devices don't support cooling. The "Cool" mode in Indigo is mapped to frost protection. Indigo commands for cool setpoints are ignored.
 
 ### Status Update Frequency
-Device status is updated every 30 seconds. Manual status request actions are not supported - the plugin logs "Status automatically updated every minute" for these requests.
+Device status is updated every 30 seconds. Manual status request actions are not supported - the plugin logs "Status automatically updated every 30 seconds" for these requests.
 
 ## Development History
 

--- a/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/MenuItems.xml
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/MenuItems.xml
@@ -4,4 +4,8 @@
         <Name>Discover NeoHub (HubSeek)</Name>
         <CallbackMethod>discoverNeohub</CallbackMethod>
     </MenuItem>
+    <MenuItem id="testConnection">
+        <Name>Test NeoHub Connection</Name>
+        <CallbackMethod>testConnection</CallbackMethod>
+    </MenuItem>
 </MenuItems>

--- a/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/PluginConfig.xml
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/PluginConfig.xml
@@ -7,7 +7,22 @@
 		<Label>Neohub IP address:</Label>
 	</Field>
 	<Field id="sep0" type="separator"/>
-	<Field id="neohubGen2" type="checkbox" defaultValue="true" tooltip="Uncheck for original NeoHub (Gen 1). Gen 2 uses newer API commands.">
+	<Field id="connectionMode" type="menu" defaultValue="wss"
+		tooltip="WSS (recommended): Secure WebSocket on port 4243 with API token. Legacy TCP: Unsecured port 4242, no auth.">
+		<Label>Connection mode:</Label>
+		<List>
+			<Option value="wss">WSS — Secure WebSocket (port 4243)</Option>
+			<Option value="tcp">Legacy TCP (port 4242)</Option>
+		</List>
+	</Field>
+	<Field id="neohubToken" type="textfield" defaultValue=""
+		visibleBindingId="connectionMode" visibleBindingValue="wss"
+		tooltip="Generate in Heatmiser Neo App: Settings > Api Access > Tokens.">
+		<Label>API Token:</Label>
+	</Field>
+	<Field id="neohubGen2" type="checkbox" defaultValue="true"
+		visibleBindingId="connectionMode" visibleBindingValue="tcp"
+		tooltip="Uncheck for original NeoHub (Gen 1). Gen 2 uses newer API commands over legacy TCP.">
 		<Label>NeoHub Gen 2 (newer hardware): </Label>
 	</Field>
 	<Field id="sep1" type="separator"/>

--- a/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/plugin.py
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/plugin.py
@@ -467,16 +467,16 @@ class Plugin(indigo.PluginBase):
         cmd_id = self._command_id
         inner_command = json.dumps({
             "token": self.neohubToken,
-            "COMMANDS": [{"COMMAND": json.loads("{" + cmdPhrase + "}"), "COMMANDID": cmd_id}]
+            "COMMANDS": [{"COMMAND": str(json.loads("{" + cmdPhrase + "}")), "COMMANDID": cmd_id}]
         })
         message = json.dumps({
             "message_type": "hm_get_command_queue",
             "message": inner_command
         })
-        if self.logComms:
-            self.logger.info("WSS --> %s" % message)
         ws = self._get_wss()
         ws.send(message)
+        if self.logComms:
+            self.logger.info("WSS --> %s" % message)
         for _ in range(5):
             response_text = ws.recv(timeout=10)
             if self.logComms:
@@ -500,15 +500,14 @@ class Plugin(indigo.PluginBase):
         except (ConnectionClosed, ConnectionError, TimeoutError, OSError) as exc:
             self._close_wss()
             self.connectErrorCount += 1
-            if self.connectErrorCount == 3:
+            if self.connectErrorCount <= 3:
                 self.logger.error("getNeoData WSS: connection error (%s)" % exc)
             return ""
         except Exception as exc:
             self._close_wss()
             self.sendErrorCount += 1
-            if self.sendErrorCount == 3:
+            if self.sendErrorCount <= 3:
                 self.logger.error("getNeoData WSS: error (%s)" % exc)
-                self.sendErrorCount = 0
             return ""
 
     def _get_neo_data_tcp(self, cmdPhrase):

--- a/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/plugin.py
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/plugin.py
@@ -20,6 +20,7 @@ try:
     HAS_WEBSOCKETS = True
 except ImportError:
     HAS_WEBSOCKETS = False
+    ConnectionClosed = type(None)  # safe fallback for except clause
 
 ################################################################################
 # Globals
@@ -170,8 +171,9 @@ class Plugin(indigo.PluginBase):
             self.neohubGen2 = True if self.connectionMode == "wss" else self._coerce_bool(valuesDict.get("neohubGen2", True))
             oldToken = self.neohubToken
             self.neohubToken = valuesDict.get("neohubToken", "").strip()
+            needs_reconnect = False
             if self.connectionMode != oldMode or self.neohubToken != oldToken:
-                self._close_wss()
+                needs_reconnect = True
                 if self.connectionMode == "wss" and self.neohubToken:
                     self.logger.info("Using WSS connection (port 4243)")
                 else:
@@ -180,6 +182,8 @@ class Plugin(indigo.PluginBase):
             self.neohubIP = valuesDict.get("neohubIP")
             if self.neohubIP != oldIP:
                 self.logger.info("Neohub IP address is now %s" % self.neohubIP)
+                needs_reconnect = True
+            if needs_reconnect:
                 self._close_wss()
 
                         
@@ -440,6 +444,10 @@ class Plugin(indigo.PluginBase):
         if self.connectionMode == "wss" and self.neohubToken and HAS_WEBSOCKETS:
             return self._get_neo_data_wss(cmdPhrase)
         else:
+            if self.connectionMode == "wss" and not getattr(self, '_wss_fallback_warned', False):
+                self.logger.warning("WSS mode configured but not available (token=%s, library=%s) — using TCP fallback"
+                    % ("set" if self.neohubToken else "missing", "available" if HAS_WEBSOCKETS else "missing"))
+                self._wss_fallback_warned = True
             return self._get_neo_data_tcp(cmdPhrase)
 
     def _close_wss(self):
@@ -447,47 +455,70 @@ class Plugin(indigo.PluginBase):
             if self._wss is not None:
                 try:
                     self._wss.close()
-                except Exception:
-                    pass
+                except Exception as exc:
+                    self.logger.debug("WSS close error (ignored): %s" % exc)
                 self._wss = None
 
-    def _get_wss(self):
-        with self._wss_lock:
-            if self._wss is not None:
-                return self._wss
-            ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-            ssl_context.check_hostname = False
-            ssl_context.verify_mode = ssl.CERT_NONE
-            uri = "wss://%s:4243" % self.neohubIP
-            self._wss = ws_connect(uri, ssl=ssl_context, open_timeout=8)
+    def _ensure_wss(self):
+        """Return existing WSS connection or create new one. Must be called under _wss_lock."""
+        if self._wss is not None:
             return self._wss
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ssl_context.check_hostname = False
+        ssl_context.verify_mode = ssl.CERT_NONE  # NeoHub uses self-signed cert on local network
+        uri = "wss://%s:4243" % self.neohubIP
+        self._wss = ws_connect(uri, ssl=ssl_context, open_timeout=8)
+        return self._wss
 
     def _send_wss(self, cmdPhrase):
-        self._command_id += 1
-        cmd_id = self._command_id
-        inner_command = json.dumps({
-            "token": self.neohubToken,
-            "COMMANDS": [{"COMMAND": str(json.loads("{" + cmdPhrase + "}")), "COMMANDID": cmd_id}]
-        })
-        message = json.dumps({
-            "message_type": "hm_get_command_queue",
-            "message": inner_command
-        })
-        ws = self._get_wss()
-        ws.send(message)
-        if self.logComms:
-            self.logger.info("WSS --> %s" % message)
-        for _ in range(5):
-            response_text = ws.recv(timeout=10)
+        """Send command via WSS and return parsed response.
+
+        The Heatmiser WSS protocol uses a two-layer JSON envelope: the outer
+        message has message_type + message fields, the inner payload contains
+        the API token and COMMANDS array. The hub may send async messages
+        between command/response pairs, so we filter for hm_set_command_response.
+        """
+        with self._wss_lock:
+            self._command_id += 1
+            cmd_id = self._command_id
+            # NeoHub WSS API expects Python-style dict string representation, not JSON
+            inner_command = json.dumps({
+                "token": self.neohubToken,
+                "COMMANDS": [{"COMMAND": str(json.loads("{" + cmdPhrase + "}")), "COMMANDID": cmd_id}]
+            })
+            message = json.dumps({
+                "message_type": "hm_get_command_queue",
+                "message": inner_command
+            })
+            ws = self._ensure_wss()
+            ws.send(message)
             if self.logComms:
-                self.logger.info("WSS <-- %s" % response_text)
-            response = json.loads(response_text)
-            if response.get("message_type") == "hm_set_command_response":
-                return json.loads(response["response"])
-        self.logger.warning("No command response received after 5 messages")
-        return ""
+                log_msg = message.replace(self.neohubToken, "***") if self.neohubToken else message
+                self.logger.info("WSS --> %s" % log_msg)
+            for _ in range(5):
+                response_text = ws.recv(timeout=10)
+                if self.logComms:
+                    self.logger.info("WSS <-- %s" % response_text)
+                try:
+                    response = json.loads(response_text)
+                except json.JSONDecodeError as exc:
+                    self.logger.error("WSS: failed to parse response: %s" % exc)
+                    continue
+                msg_type = response.get("message_type", "unknown")
+                if msg_type == "hm_set_command_response":
+                    try:
+                        return json.loads(response["response"])
+                    except (json.JSONDecodeError, KeyError) as exc:
+                        self.logger.error("WSS: failed to parse command response: %s" % exc)
+                        return ""
+                else:
+                    self.logger.debug("WSS: skipping message type '%s'" % msg_type)
+            self.logger.warning("No command response received after 5 messages")
+            return ""
 
     def _get_neo_data_wss(self, cmdPhrase):
+        """WSS equivalent of _get_neo_data_tcp. On connection failure, closes
+        the persistent socket so the next call reconnects via _ensure_wss."""
         try:
             result = self._send_wss(cmdPhrase)
             self.connectErrorCount = 0
@@ -500,14 +531,14 @@ class Plugin(indigo.PluginBase):
         except (ConnectionClosed, ConnectionError, TimeoutError, OSError) as exc:
             self._close_wss()
             self.connectErrorCount += 1
-            if self.connectErrorCount <= 3:
-                self.logger.error("getNeoData WSS: connection error (%s)" % exc)
+            if self.connectErrorCount <= 3 or self.connectErrorCount % 10 == 0:
+                self.logger.error("getNeoData WSS: connection error #%d (%s)" % (self.connectErrorCount, exc))
             return ""
         except Exception as exc:
             self._close_wss()
             self.sendErrorCount += 1
-            if self.sendErrorCount <= 3:
-                self.logger.error("getNeoData WSS: error (%s)" % exc)
+            if self.sendErrorCount <= 3 or self.sendErrorCount % 10 == 0:
+                self.logger.error("getNeoData WSS: unexpected error #%d [%s]: %s" % (self.sendErrorCount, type(exc).__name__, exc))
             return ""
 
     def _get_neo_data_tcp(self, cmdPhrase):
@@ -717,9 +748,11 @@ class Plugin(indigo.PluginBase):
         mode = "WSS (port 4243)" if (self.connectionMode == "wss" and self.neohubToken and HAS_WEBSOCKETS) else "TCP (port 4242)"
         self.logger.info("Testing %s connection to %s..." % (mode, self.neohubIP))
         result = self.getNeoData('"GET_LIVE_DATA":0' if self.neohubGen2 else '"INFO":0')
-        if result and result != "":
+        if result and isinstance(result, dict):
             count = len(result.get("devices", []))
             self.logger.info("Connection OK — found %d devices" % count)
+        elif result:
+            self.logger.info("Connection OK — received response")
         else:
             self.logger.error("Connection test failed")
 

--- a/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/plugin.py
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/plugin.py
@@ -10,7 +10,16 @@
 import re
 import json
 import socket
+import ssl
 import datetime
+import threading
+
+try:
+    from websockets.sync.client import connect as ws_connect
+    from websockets.exceptions import ConnectionClosed
+    HAS_WEBSOCKETS = True
+except ImportError:
+    HAS_WEBSOCKETS = False
 
 ################################################################################
 # Globals
@@ -41,11 +50,16 @@ class Plugin(indigo.PluginBase):
         self.neohubIP = pluginPrefs.get("neohubIP", "127.0.0.1")
         self.logComms = self._coerce_bool(pluginPrefs.get("logComms", False))
         self.timeSync = self._coerce_bool(pluginPrefs.get("timeSync", False))
-        self.neohubGen2 = self._coerce_bool(pluginPrefs.get("neohubGen2", True))
+        self.connectionMode = pluginPrefs.get("connectionMode", "wss")
+        self.neohubGen2 = True if self.connectionMode == "wss" else self._coerce_bool(pluginPrefs.get("neohubGen2", True))
+        self.neohubToken = pluginPrefs.get("neohubToken", "").strip()
         self.commsEnabled = True
         self.connectErrorCount = 0
         self.sendErrorCount = 0
         self.neoDevice = None
+        self._wss = None
+        self._wss_lock = threading.Lock()
+        self._command_id = 0
         self.timeUpdateRequired = None
         self.dcbUpdateRequired = None
         self.engUpdateRequired = None
@@ -56,10 +70,18 @@ class Plugin(indigo.PluginBase):
     ########################################
     def startup(self):
         self.logger.info("Starting Heatmiser Neo plugin")
-        if self.neohubGen2:
-            self.logger.info("Using NeoHub Gen 2 API")
+        if self.connectionMode == "wss":
+            if not self.neohubToken:
+                self.logger.warning("WSS mode selected but no API token configured — enter token in plugin preferences")
+            elif not HAS_WEBSOCKETS:
+                self.logger.warning("WSS mode selected but websockets library not available — falling back to legacy TCP (port 4242)")
+            else:
+                self.logger.info("Using WSS connection (port 4243)")
         else:
-            self.logger.info("Using NeoHub Gen 1 (legacy) API")
+            if self.neohubGen2:
+                self.logger.info("Using legacy TCP connection (port 4242) with Gen 2 API commands")
+            else:
+                self.logger.info("Using legacy TCP connection (port 4242) with Gen 1 API commands")
         if self.logComms:
             self.logger.info("Neo comms logging is on")
         else:
@@ -79,6 +101,7 @@ class Plugin(indigo.PluginBase):
     def shutdown(self):
         self.logger.info("Stopping Heatmiser Neo plugin")
         self.commsEnabled = False
+        self._close_wss()
 
         
     ########################################
@@ -142,11 +165,22 @@ class Plugin(indigo.PluginBase):
                     self.ntpOn()
                     self.logger.info("Neo time will be syncronised via NTP server")
                 self.updateDCB()
-            self.neohubGen2 = self._coerce_bool(valuesDict.get("neohubGen2", True))
+            oldMode = self.connectionMode
+            self.connectionMode = valuesDict.get("connectionMode", "wss")
+            self.neohubGen2 = True if self.connectionMode == "wss" else self._coerce_bool(valuesDict.get("neohubGen2", True))
+            oldToken = self.neohubToken
+            self.neohubToken = valuesDict.get("neohubToken", "").strip()
+            if self.connectionMode != oldMode or self.neohubToken != oldToken:
+                self._close_wss()
+                if self.connectionMode == "wss" and self.neohubToken:
+                    self.logger.info("Using WSS connection (port 4243)")
+                else:
+                    self.logger.info("Using legacy TCP connection (port 4242)")
             oldIP = self.neohubIP
             self.neohubIP = valuesDict.get("neohubIP")
             if self.neohubIP != oldIP:
                 self.logger.info("Neohub IP address is now %s" % self.neohubIP)
+                self._close_wss()
 
                         
     ########################################
@@ -401,63 +435,137 @@ class Plugin(indigo.PluginBase):
 
 
     def getNeoData(self, cmdPhrase):
-        if self.commsEnabled:
-            tcp_ip = self.neohubIP
-            tcp_port = 4242
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.settimeout(8)
-            try:
-                try:
-                    sock.connect((tcp_ip, tcp_port))
-                    self.connectErrorCount = 0
-                except socket.timeout:
-                    self.connectErrorCount += 1
-                    if (self.connectErrorCount == 3):
-                        self.logger.error("getNeoData: Socket timeout error")
-                    return ""
-                except Exception:
-                    self.connectErrorCount += 1
-                    if (self.connectErrorCount == 3):
-                        self.logger.error("getNeoData: Socket connect error")
-                    return ""
-                cmdPhrase = b"{"+bytes(cmdPhrase, 'ascii')+b"}"
-                try:
-                    if self.logComms:
-                        self.logger.info("--> %s" % cmdPhrase)
-                    sock.send(cmdPhrase+b"\0")
-                    dataj = None
-                    dataj = sock.recv(4096)
-                    while ((b"GET_LIVE_DATA" in cmdPhrase or b"INFO" in cmdPhrase) and (b"}]}" not in dataj[len(dataj)-5:len(dataj)-1])) or ((b"GET_ENGINEERS" in cmdPhrase or b"ENGINEERS_DATA" in cmdPhrase) and (b"}}" not in dataj[len(dataj)-4:len(dataj)-1])):
-                        chunk = sock.recv(4096)
-                        if not chunk:
-                            raise ConnectionError("NeoHub connection closed unexpectedly")
-                        dataj = dataj + chunk
-                    self.sendErrorCount = 0
-                    if self.logComms:
-                        self.logger.info("<-- %s" % dataj)
-                except socket.error as v:
-                    self.sendErrorCount += 1
-                    if (self.sendErrorCount == 3):
-                        self.logger.error("getNeoData: Socket send error (%s)" % v)
-                        self.sendErrorCount = 0
-                    return ""
-                if dataj != None:
-                    datak = re.sub(b'[^\s!-~]', b'', dataj)   #Filter extraneous characters which cause json decode to fail
-                    data = json.loads(datak)
-                    self.connectErrorCount = 0
-                    self.sendErrorCount = 0
-                    if "error" in data:
-                        self.logger.error("Command: %s" % cmdPhrase)
-                        self.logger.error(data["error"])
-                        return ""
-                    else:
-                        return data
-                else:
-                    return ""
-            finally:
-                sock.close()
-        else:
+        if not self.commsEnabled:
             return ""
+        if self.connectionMode == "wss" and self.neohubToken and HAS_WEBSOCKETS:
+            return self._get_neo_data_wss(cmdPhrase)
+        else:
+            return self._get_neo_data_tcp(cmdPhrase)
+
+    def _close_wss(self):
+        with self._wss_lock:
+            if self._wss is not None:
+                try:
+                    self._wss.close()
+                except Exception:
+                    pass
+                self._wss = None
+
+    def _get_wss(self):
+        with self._wss_lock:
+            if self._wss is not None:
+                return self._wss
+            ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = ssl.CERT_NONE
+            uri = "wss://%s:4243" % self.neohubIP
+            self._wss = ws_connect(uri, ssl=ssl_context, open_timeout=8)
+            return self._wss
+
+    def _send_wss(self, cmdPhrase):
+        self._command_id += 1
+        cmd_id = self._command_id
+        inner_command = json.dumps({
+            "token": self.neohubToken,
+            "COMMANDS": [{"COMMAND": json.loads("{" + cmdPhrase + "}"), "COMMANDID": cmd_id}]
+        })
+        message = json.dumps({
+            "message_type": "hm_get_command_queue",
+            "message": inner_command
+        })
+        if self.logComms:
+            self.logger.info("WSS --> %s" % message)
+        ws = self._get_wss()
+        ws.send(message)
+        for _ in range(5):
+            response_text = ws.recv(timeout=10)
+            if self.logComms:
+                self.logger.info("WSS <-- %s" % response_text)
+            response = json.loads(response_text)
+            if response.get("message_type") == "hm_set_command_response":
+                return json.loads(response["response"])
+        self.logger.warning("No command response received after 5 messages")
+        return ""
+
+    def _get_neo_data_wss(self, cmdPhrase):
+        try:
+            result = self._send_wss(cmdPhrase)
+            self.connectErrorCount = 0
+            self.sendErrorCount = 0
+            if isinstance(result, dict) and "error" in result:
+                self.logger.error("Command: {%s}" % cmdPhrase)
+                self.logger.error(result["error"])
+                return ""
+            return result
+        except (ConnectionClosed, ConnectionError, TimeoutError, OSError) as exc:
+            self._close_wss()
+            self.connectErrorCount += 1
+            if self.connectErrorCount == 3:
+                self.logger.error("getNeoData WSS: connection error (%s)" % exc)
+            return ""
+        except Exception as exc:
+            self._close_wss()
+            self.sendErrorCount += 1
+            if self.sendErrorCount == 3:
+                self.logger.error("getNeoData WSS: error (%s)" % exc)
+                self.sendErrorCount = 0
+            return ""
+
+    def _get_neo_data_tcp(self, cmdPhrase):
+        tcp_ip = self.neohubIP
+        tcp_port = 4242
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(8)
+        try:
+            try:
+                sock.connect((tcp_ip, tcp_port))
+                self.connectErrorCount = 0
+            except socket.timeout:
+                self.connectErrorCount += 1
+                if (self.connectErrorCount == 3):
+                    self.logger.error("getNeoData: Socket timeout error")
+                return ""
+            except Exception:
+                self.connectErrorCount += 1
+                if (self.connectErrorCount == 3):
+                    self.logger.error("getNeoData: Socket connect error")
+                return ""
+            cmdPhrase = b"{"+bytes(cmdPhrase, 'ascii')+b"}"
+            try:
+                if self.logComms:
+                    self.logger.info("--> %s" % cmdPhrase)
+                sock.send(cmdPhrase+b"\0")
+                dataj = None
+                dataj = sock.recv(4096)
+                while ((b"GET_LIVE_DATA" in cmdPhrase or b"INFO" in cmdPhrase) and (b"}]}" not in dataj[len(dataj)-5:len(dataj)-1])) or ((b"GET_ENGINEERS" in cmdPhrase or b"ENGINEERS_DATA" in cmdPhrase) and (b"}}" not in dataj[len(dataj)-4:len(dataj)-1])):
+                    chunk = sock.recv(4096)
+                    if not chunk:
+                        raise ConnectionError("NeoHub connection closed unexpectedly")
+                    dataj = dataj + chunk
+                self.sendErrorCount = 0
+                if self.logComms:
+                    self.logger.info("<-- %s" % dataj)
+            except socket.error as v:
+                self.sendErrorCount += 1
+                if (self.sendErrorCount == 3):
+                    self.logger.error("getNeoData: Socket send error (%s)" % v)
+                    self.sendErrorCount = 0
+                return ""
+            if dataj != None:
+                datak = re.sub(b'[^\s!-~]', b'', dataj)   #Filter extraneous characters which cause json decode to fail
+                data = json.loads(datak)
+                self.connectErrorCount = 0
+                self.sendErrorCount = 0
+                if "error" in data:
+                    self.logger.error("Command: %s" % cmdPhrase)
+                    self.logger.error(data["error"])
+                    return ""
+                else:
+                    return data
+            else:
+                return ""
+        finally:
+            sock.close()
 
 
     def checkTime(self):
@@ -606,6 +714,15 @@ class Plugin(indigo.PluginBase):
         finally:
             sock.close()
 
+    def testConnection(self):
+        mode = "WSS (port 4243)" if (self.connectionMode == "wss" and self.neohubToken and HAS_WEBSOCKETS) else "TCP (port 4242)"
+        self.logger.info("Testing %s connection to %s..." % (mode, self.neohubIP))
+        result = self.getNeoData('"GET_LIVE_DATA":0' if self.neohubGen2 else '"INFO":0')
+        if result and result != "":
+            count = len(result.get("devices", []))
+            self.logger.info("Connection OK — found %d devices" % count)
+        else:
+            self.logger.error("Connection test failed")
 
 
     ########################################


### PR DESCRIPTION
## Summary
- Add WSS connection mode (port 4243) with token authentication as alternative to legacy TCP (port 4242)
- Connection mode selector in plugin preferences (WSS/Legacy TCP) with API token field
- Persistent WebSocket connection with thread-safe management and automatic reconnection
- Test Connection menu item to verify connectivity
- Improved WSS error logging (first 3 errors logged, log after send)

## Test plan
- [x] WSS connection working against live NeoHub
- [ ] Verify legacy TCP mode still works when selected
- [ ] Confirm connection mode switching in plugin preferences
- [ ] Test connection recovery after NeoHub restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Test NeoHub Connection" menu option to verify connectivity and report device count.
  * Added secure WebSocket (WSS) support for Gen2 NeoHub alongside legacy TCP.
  * Added connection mode selector and an API token field (visible when WSS selected).
  * Added daily time synchronization option for Neo devices.

* **Documentation**
  * Updated usage and connection behavior guidance to reflect WSS/TCP options and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->