### PR TITLE
Add missing NeoHub device states and actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,8 +77,16 @@ On startup, the plugin queries the Neohub for all connected devices ([plugin.py:
 - Current temperature, setpoint, heat state
 - Pre-heat mode, frost protection (mapped to "Cool" mode)
 - Away/Holiday modes
+- Hold time remaining and hold temperature
+- Window open, low battery, keypad locked
+- Floor temperature (when probe present, 127 = no probe)
 - Hub firmware version, DST/NTP status (stored on first device)
 - Engineering data: Rate of Change, Frost Temp, Switching Differential
+
+**NeoTimeclock** tracks:
+- On/Off state, temperature, short mode
+- Away/Holiday modes
+- Hold time remaining (for timer boost)
 
 **NeoPlug** tracks:
 - On/Off state based on timer status
@@ -118,7 +126,18 @@ Defined in [Actions.xml](HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/Action
    - Temperature: 10-25°C
 2. **Building Protection** (`setCool`): Enable frost protection mode
 3. **Auto Mode** (`setAuto`): Return to programmed schedule
-4. **Change Neohub IP** (`changeIp`): Update IP address without plugin restart
+4. **Timer Boost** (`timerBoost`): Boost timeclock device on for set duration
+5. **Cancel Timer Boost** (`timerBoostOff`): Cancel active timer boost
+6. **Set Holiday** (`setHoliday`): Set all devices to holiday mode until end date
+7. **Cancel Holiday** (`cancelHoliday`): Cancel holiday mode
+8. **Away Mode On** (`awayOn`): Set device to away mode (reduced temperature)
+9. **Away Mode Off** (`awayOff`): Cancel away mode, restore schedule
+10. **Lock Keypad** (`lockKeypad`): Lock thermostat keypad with 4-digit PIN
+11. **Unlock Keypad** (`unlockKeypad`): Remove keypad lock
+12. **Cancel Hold** (`cancelHold`): Cancel active temperature hold
+13. **Set Frost Temp** (`setFrostTemp`): Set frost protection temperature per device
+14. **Identify Device** (`identifyDevice`): Flash LED to locate a device
+15. **Change Neohub IP** (`changeIp`): Update IP address without plugin restart
 
 ## Key Implementation Details
 

--- a/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/Actions.xml
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/Actions.xml
@@ -124,4 +124,64 @@
             </Field>
         </ConfigUI>
     </Action>
+    <Action id="awayOn" deviceFilter="self">
+        <Name>Away Mode On</Name>
+        <CallbackMethod>awayOn</CallbackMethod>
+        <ConfigUI>
+            <Field id="awayOnLabel" type="label">
+                <Label>Sets device to away mode (reduced temperature).</Label>
+            </Field>
+        </ConfigUI>
+    </Action>
+    <Action id="awayOff" deviceFilter="self">
+        <Name>Away Mode Off</Name>
+        <CallbackMethod>awayOff</CallbackMethod>
+        <ConfigUI>
+            <Field id="awayOffLabel" type="label">
+                <Label>Cancels away mode and restores schedule.</Label>
+            </Field>
+        </ConfigUI>
+    </Action>
+    <Action id="lockKeypad" deviceFilter="self.heatmiserNeostat">
+        <Name>Lock Keypad</Name>
+        <CallbackMethod>lockKeypad</CallbackMethod>
+        <ConfigUI>
+            <Field id="lockPin" type="textfield" defaultValue="0000">
+                <Label>PIN (4 digits):</Label>
+            </Field>
+        </ConfigUI>
+    </Action>
+    <Action id="unlockKeypad" deviceFilter="self.heatmiserNeostat">
+        <Name>Unlock Keypad</Name>
+        <CallbackMethod>unlockKeypad</CallbackMethod>
+    </Action>
+    <Action id="cancelHold" deviceFilter="self.heatmiserNeostat">
+        <Name>Cancel Temperature Hold</Name>
+        <CallbackMethod>cancelHold</CallbackMethod>
+        <ConfigUI>
+            <Field id="cancelHoldLabel" type="label">
+                <Label>Cancels active temperature hold and returns to schedule.</Label>
+            </Field>
+        </ConfigUI>
+    </Action>
+    <Action id="setFrostTemp" deviceFilter="self.heatmiserNeostat">
+        <Name>Set Frost Protection Temperature</Name>
+        <CallbackMethod>setFrostTemp</CallbackMethod>
+        <ConfigUI>
+            <Field type="menu" id="frostTemp" defaultValue="12">
+                <Label>Frost temperature:</Label>
+                <List>
+                    <Option value="5">5 °C</Option>
+                    <Option value="7">7 °C</Option>
+                    <Option value="10">10 °C</Option>
+                    <Option value="12">12 °C</Option>
+                    <Option value="15">15 °C</Option>
+                </List>
+            </Field>
+        </ConfigUI>
+    </Action>
+    <Action id="identifyDevice" deviceFilter="self">
+        <Name>Identify Device (Flash LED)</Name>
+        <CallbackMethod>identifyDevice</CallbackMethod>
+    </Action>
 </Actions>

--- a/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/Devices.xml
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/Devices.xml
@@ -95,6 +95,36 @@
 				<TriggerLabel>Switching Differential (deg)</TriggerLabel>
 				<ControlPageLabel>Switching Differential (deg)</ControlPageLabel>
 			</State>
+			<State id="HoldTimeRemaining">
+				<ValueType>String</ValueType>
+				<TriggerLabel>Hold Time Remaining</TriggerLabel>
+				<ControlPageLabel>Hold Time Remaining</ControlPageLabel>
+			</State>
+			<State id="HoldTemperature">
+				<ValueType>Number</ValueType>
+				<TriggerLabel>Hold Temperature</TriggerLabel>
+				<ControlPageLabel>Hold Temperature</ControlPageLabel>
+			</State>
+			<State id="WindowOpen">
+				<ValueType>Boolean</ValueType>
+				<TriggerLabel>Window Open</TriggerLabel>
+				<ControlPageLabel>Window Open</ControlPageLabel>
+			</State>
+			<State id="lowBattery">
+				<ValueType>Boolean</ValueType>
+				<TriggerLabel>Low Battery</TriggerLabel>
+				<ControlPageLabel>Low Battery</ControlPageLabel>
+			</State>
+			<State id="FloorTemperature">
+				<ValueType>Number</ValueType>
+				<TriggerLabel>Floor Temperature</TriggerLabel>
+				<ControlPageLabel>Floor Temperature</ControlPageLabel>
+			</State>
+			<State id="Locked">
+				<ValueType>Boolean</ValueType>
+				<TriggerLabel>Keypad Locked</TriggerLabel>
+				<ControlPageLabel>Keypad Locked</ControlPageLabel>
+			</State>
 		</States>
 	</Device>
 	<Device type="relay" id="heatmiserNeoTimeclock" allowUserCreation="false">
@@ -124,6 +154,11 @@
 				<ValueType>Boolean</ValueType>
 				<TriggerLabel>Away Mode</TriggerLabel>
 				<ControlPageLabel>Away Mode</ControlPageLabel>
+			</State>
+			<State id="HoldTimeRemaining">
+				<ValueType>String</ValueType>
+				<TriggerLabel>Hold Time Remaining</TriggerLabel>
+				<ControlPageLabel>Hold Time Remaining</ControlPageLabel>
 			</State>
 		</States>
 	</Device>

--- a/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/plugin.py
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/plugin.py
@@ -340,6 +340,7 @@ class Plugin(indigo.PluginBase):
                 {"key": "ShortMode", "value": shortMode},
                 {"key": "Away", "value": devData.get("AWAY", False)},
                 {"key": "Holiday", "value": devData.get("HOLIDAY", False)},
+                {"key": "HoldTimeRemaining", "value": devData.get("HOLD_TIME", "0:00")},
             ]
             if curTemp > 0:
                 stateList.append({"key": "temperatureInput1", "value": curTemp, "uiValue": "%s °C" % curTemp, "clearErrorState": True})
@@ -381,7 +382,17 @@ class Plugin(indigo.PluginBase):
                 {"key": "ShortMode", "value": shortMode},
                 {"key": "Away", "value": devData.get("AWAY", False)},
                 {"key": "Holiday", "value": devData.get("HOLIDAY", False)},
+                {"key": "HoldTimeRemaining", "value": devData.get("HOLD_TIME", "0:00")},
+                {"key": "HoldTemperature", "value": devData.get("HOLD_TEMP", 0)},
+                {"key": "WindowOpen", "value": devData.get("WINDOW_OPEN", False)},
+                {"key": "lowBattery", "value": devData.get("LOW_BATTERY", False)},
+                {"key": "Locked", "value": devData.get("LOCK", False)},
             ]
+
+            floorTemp = devData.get("CURRENT_FLOOR_TEMPERATURE", 127)
+            if floorTemp != 127:
+                stateList.append({"key": "FloorTemperature", "value": round(float(floorTemp), 1),
+                                   "uiValue": "%s °C" % round(float(floorTemp), 1)})
 
             if curTemp > 0:
                 stateList.append({"key": "temperatureInput1", "value": curTemp, "uiValue": "%s °C" % curTemp, "clearErrorState": True})
@@ -869,6 +880,65 @@ class Plugin(indigo.PluginBase):
             self.logger.info("Holiday mode cancelled")
         else:
             self.logger.error("Cancel Holiday command failed")
+
+    def awayOn(self, pluginAction):
+        device = indigo.devices[pluginAction.deviceId].name
+        update = self.getNeoData('"AWAY_ON":["%s"]' % device)
+        if update and "result" in update:
+            self.logger.info("%s away mode on" % device)
+        else:
+            self.logger.error("%s away on command failed" % device)
+
+    def awayOff(self, pluginAction):
+        device = indigo.devices[pluginAction.deviceId].name
+        update = self.getNeoData('"AWAY_OFF":["%s"]' % device)
+        if update and "result" in update:
+            self.logger.info("%s away mode off" % device)
+        else:
+            self.logger.error("%s away off command failed" % device)
+
+    def lockKeypad(self, pluginAction):
+        device = indigo.devices[pluginAction.deviceId].name
+        pin = pluginAction.props.get("lockPin", "0000")
+        digits = [int(d) for d in pin[:4]]
+        update = self.getNeoData('"LOCK":[[%s], ["%s"]]' % (",".join(str(d) for d in digits), device))
+        if update and "result" in update:
+            self.logger.info("%s keypad locked" % device)
+        else:
+            self.logger.error("%s lock keypad command failed" % device)
+
+    def unlockKeypad(self, pluginAction):
+        device = indigo.devices[pluginAction.deviceId].name
+        update = self.getNeoData('"UNLOCK":["%s"]' % device)
+        if update and "result" in update:
+            self.logger.info("%s keypad unlocked" % device)
+        else:
+            self.logger.error("%s unlock keypad command failed" % device)
+
+    def cancelHold(self, pluginAction):
+        device = indigo.devices[pluginAction.deviceId].name
+        update = self.getNeoData('"HOLD":[{"temp":20, "id":"Off", "hours":0, "minutes":0}, "%s"]' % device)
+        if update and "result" in update:
+            self.logger.info("%s hold cancelled" % device)
+        else:
+            self.logger.error("%s cancel hold command failed" % device)
+
+    def setFrostTemp(self, pluginAction):
+        device = indigo.devices[pluginAction.deviceId].name
+        temp = pluginAction.props.get("frostTemp", "12")
+        update = self.getNeoData('"SET_FROST":[%s, "%s"]' % (temp, device))
+        if update and "result" in update:
+            self.logger.info("%s frost temperature set to %s°C" % (device, temp))
+        else:
+            self.logger.error("%s set frost temp command failed" % device)
+
+    def identifyDevice(self, pluginAction):
+        device = indigo.devices[pluginAction.deviceId].name
+        update = self.getNeoData('"IDENTIFY":[1, 3, ["%s"]]' % device)
+        if update and "result" in update:
+            self.logger.info("%s identify LED flashing" % device)
+        else:
+            self.logger.error("%s identify command failed" % device)
 
     def changeIp(self, action):
         oldIP = self.neohubIP

--- a/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/plugin.py
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/plugin.py
@@ -308,8 +308,11 @@ class Plugin(indigo.PluginBase):
             # Update Holiday_End from top-level response on first device
             if self.neoDevice is not None:
                 holidayEnd = update.get("HOLIDAY_END", 0)
-                if holidayEnd and holidayEnd > 0:
-                    endDate = datetime.datetime.fromtimestamp(holidayEnd).strftime("%d/%m/%Y %H:%M")
+                if holidayEnd and str(holidayEnd) not in ("0", ""):
+                    if isinstance(holidayEnd, (int, float)):
+                        endDate = datetime.datetime.fromtimestamp(holidayEnd).strftime("%d/%m/%Y %H:%M")
+                    else:
+                        endDate = str(holidayEnd)
                 else:
                     endDate = "None"
                 self.neoDevice.updateStateOnServer(key="Holiday_End", value=endDate)

--- a/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/plugin.py
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/plugin.py
@@ -305,17 +305,6 @@ class Plugin(indigo.PluginBase):
                     self.updateStatState(update, stat, device)
                     if stat == 0:
                         self.neoDevice = device
-            # Update Holiday_End from top-level response on first device
-            if self.neoDevice is not None:
-                holidayEnd = update.get("HOLIDAY_END", 0)
-                if holidayEnd and str(holidayEnd) not in ("0", ""):
-                    if isinstance(holidayEnd, (int, float)):
-                        endDate = datetime.datetime.fromtimestamp(holidayEnd).strftime("%d/%m/%Y %H:%M")
-                    else:
-                        endDate = str(holidayEnd)
-                else:
-                    endDate = "None"
-                self.neoDevice.updateStateOnServer(key="Holiday_End", value=endDate)
     
             
     def updateStatState(self, neoRep, index, indigoDevice):
@@ -391,6 +380,17 @@ class Plugin(indigo.PluginBase):
                 {"key": "lowBattery", "value": devData.get("LOW_BATTERY", False)},
                 {"key": "Locked", "value": devData.get("LOCK", False)},
             ]
+
+            # Holiday_End is a hub-level field — set on every neostat so all devices show it
+            holidayEnd = neoRep.get("HOLIDAY_END", 0)
+            if holidayEnd and str(holidayEnd) not in ("0", ""):
+                if isinstance(holidayEnd, (int, float)):
+                    endDate = datetime.datetime.fromtimestamp(holidayEnd).strftime("%d/%m/%Y %H:%M")
+                else:
+                    endDate = str(holidayEnd).strip()
+                stateList.append({"key": "Holiday_End", "value": endDate})
+            else:
+                stateList.append({"key": "Holiday_End", "value": "None"})
 
             floorTemp = devData.get("CURRENT_FLOOR_TEMPERATURE", 127)
             if floorTemp != 127:


### PR DESCRIPTION
## Summary
- **6 new device states** on neostats: `HoldTimeRemaining`, `HoldTemperature`, `WindowOpen`, `lowBattery`, `FloorTemperature`, `Locked` — extracted from GET_LIVE_DATA fields
- **1 new state** on timeclocks: `HoldTimeRemaining`
- **7 new actions**: Away On/Off, Lock/Unlock Keypad, Cancel Hold, Set Frost Temp, Identify Device
- Floor temperature only stored when probe present (127 = no probe)
- Updated CLAUDE.md with complete state and action documentation

## Test plan
- [ ] Reload plugin — new states appear on thermostat devices with values
- [ ] Trigger a temperature hold — `HoldTimeRemaining` counts down, `HoldTemperature` shows held temp
- [ ] Test Away On/Off via action menu
- [ ] Test Lock/Unlock Keypad with PIN
- [ ] Test Cancel Hold, Set Frost Temp, Identify Device actions
- [ ] Verify `WindowOpen`, `lowBattery`, `Locked` reflect actual device state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Away mode on/off, keypad lock/unlock (4-digit PIN), cancel temperature hold, set frost temperature, and device identify
  * Enhanced device states: hold time remaining (thermostat and timeclock), hold temperature, window-open, low battery, floor temperature, and lock status

* **Documentation**
  * Expanded architecture docs covering device-state details and the broader action set
<!-- end of auto-generated comment: release notes by coderabbit.ai -->