### PR TITLE
fix: remove illegal onOffState override in relay devices

### DIFF
--- a/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/Devices.xml
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/Devices.xml
@@ -10,11 +10,6 @@
 	<Device type="relay" id="heatmiserNeoplug" allowUserCreation="false">
 		<Name>Heatmiser Neoplug</Name>
 		<States>
-			<State id="onOffState">
-				<ValueType>Boolean</ValueType>
-				<TriggerLabel>Neoplug On</TriggerLabel>
-				<ControlPageLabel>Neoplug Status</ControlPageLabel>
-			</State>
 		</States>
 	</Device>
 	<Device type="thermostat" id="heatmiserNeostat" allowUserCreation="false">
@@ -100,11 +95,6 @@
 	<Device type="relay" id="heatmiserNeoTimeclock" allowUserCreation="false">
 		<Name>Heatmiser Neo Timeclock</Name>
 		<States>
-			<State id="onOffState">
-				<ValueType>Boolean</ValueType>
-				<TriggerLabel>Timeclock On</TriggerLabel>
-				<ControlPageLabel>Timeclock Status</ControlPageLabel>
-			</State>
 			<State id="temperatureInput1">
 				<ValueType>Number</ValueType>
 				<TriggerLabel>Temperature</TriggerLabel>


### PR DESCRIPTION
## Summary
- Removes `onOffState` declarations from Neoplug and NeoTimeclock devices in Devices.xml
- Relay-type devices get `onOffState` as a native state from Indigo, so redefining it causes an error on device edit

## Test plan
- [ ] Verify Neoplug and NeoTimeclock devices can be edited without errors
- [ ] Confirm on/off state still works correctly for relay devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)