### PR TITLE
feat: add CI workflows for version validation and auto-release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,53 @@
+name: Create Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from Info.plist
+        id: get_version
+        run: |
+          VERSION=$(grep -A1 '<key>PluginVersion</key>' "HeatmiserNeo.IndigoPlugin/Contents/Info.plist" | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Found version: $VERSION"
+
+      - name: Check if tag already exists
+        id: check_tag
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          if git tag -l | grep -q "^${VERSION}$"; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Tag ${VERSION} already exists, skipping release creation"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Tag ${VERSION} does not exist, will create release"
+          fi
+
+      - name: Create plugin bundle zip
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          zip -r "HeatmiserNeo.IndigoPlugin.zip" "HeatmiserNeo.IndigoPlugin"
+          echo "Created HeatmiserNeo.IndigoPlugin.zip"
+
+      - name: Create Release
+        if: steps.check_tag.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.get_version.outputs.version }}
+          name: Release ${{ steps.get_version.outputs.version }}
+          generate_release_notes: true
+          files: HeatmiserNeo.IndigoPlugin.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,30 @@
+name: Version Check
+
+on:
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from Info.plist
+        id: get_version
+        run: |
+          VERSION=$(grep -A1 '<key>PluginVersion</key>' "HeatmiserNeo.IndigoPlugin/Contents/Info.plist" | grep '<string>' | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Found version: $VERSION"
+
+      - name: Check if version tag already exists
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          if git tag -l | grep -q "^${VERSION}$"; then
+            echo "::error::Version ${VERSION} already exists as a tag. Please update the version in Info.plist."
+            exit 1
+          fi
+          echo "Version ${VERSION} is unique - check passed"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,23 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Integrates Heatmiser Neo heating system with Indigo home automation via the Neohub central controller.
 
+## Versioning & Release
+
+### Version bump is required for every PR
+
+The `PluginVersion` in `HeatmiserNeo.IndigoPlugin/Contents/Info.plist` must be bumped in every PR. CI runs a version-check that fails if the version already exists as a git tag. **Do not merge with failing checks.**
+
+Version format: `YYYY.R.patch` (e.g. `2026.0.2`). Bump the patch for fixes/docs, minor for features.
+
+On merge to main, the `create-release` workflow automatically creates a GitHub release with a `.zip` bundle of the plugin.
+
+### PR checklist
+
+1. Bump `PluginVersion` in `Info.plist`
+2. Push and create PR
+3. Wait for version-check CI to pass
+4. Merge only after all checks are green
+
 ## Architecture
 
 ### Communication Protocol

--- a/HeatmiserNeo.IndigoPlugin/Contents/Info.plist
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2026.0.1</string>
+	<string>2026.0.2</string>
 	<key>ServerApiVersion</key>
 	<string>3.0</string>
 	<key>IwsApiVersion</key>


### PR DESCRIPTION
## Summary
- Adds `version-check.yml` — blocks PRs if `PluginVersion` in Info.plist hasn't been bumped
- Adds `create-release.yml` — auto-creates tagged GitHub release with `.zip` bundle on merge to main
- Documents versioning & release process in CLAUDE.md
- Bumps version to `2026.0.2`

Matches the CI pattern used by netro, UK-Trains, mqtt-device-sniffer, and indigo-domio-plugin.

## Test plan
- [ ] Version-check CI passes on this PR
- [ ] Release created automatically on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)