### PR TITLE
feat: add GetHoursRun and GetTempLog actions

### DIFF
--- a/HeatmiserNeo.IndigoPlugin/Contents/Info.plist
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2026.0.3</string>
+	<string>2026.0.4</string>
 	<key>ServerApiVersion</key>
 	<string>3.0</string>
 	<key>IwsApiVersion</key>

--- a/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/Actions.xml
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/Actions.xml
@@ -184,4 +184,22 @@
         <Name>Identify Device (Flash LED)</Name>
         <CallbackMethod>identifyDevice</CallbackMethod>
     </Action>
+    <Action id="getHoursRun" deviceFilter="self.heatmiserNeostat">
+        <Name>Get Hours Run (last 7 days)</Name>
+        <CallbackMethod>getHoursRun</CallbackMethod>
+        <ConfigUI>
+            <Field id="getHoursRunLabel" type="label">
+                <Label>Fetches the number of hours the output was on per day for the last 7 days. Result is logged to the Indigo Event Log.</Label>
+            </Field>
+        </ConfigUI>
+    </Action>
+    <Action id="getTempLog" deviceFilter="self.heatmiserNeostat">
+        <Name>Get Temperature Log (last 7 days)</Name>
+        <CallbackMethod>getTempLog</CallbackMethod>
+        <ConfigUI>
+            <Field id="getTempLogLabel" type="label">
+                <Label>Fetches temperature readings for the last 7 days in 15-minute intervals. Result is logged to the Indigo Event Log.</Label>
+            </Field>
+        </ConfigUI>
+    </Action>
 </Actions>

--- a/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/plugin.py
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/plugin.py
@@ -960,6 +960,22 @@ class Plugin(indigo.PluginBase):
         else:
             self.logger.error("%s identify command failed" % device)
 
+    def getHoursRun(self, pluginAction):
+        device = indigo.devices[pluginAction.deviceId].name
+        update = self.getNeoData('"GET_HOURSRUN":"%s"' % device)
+        if update:
+            self.logger.info("%s hours run: %s" % (device, json.dumps(update)))
+        else:
+            self.logger.error("%s get hours run command failed" % device)
+
+    def getTempLog(self, pluginAction):
+        device = indigo.devices[pluginAction.deviceId].name
+        update = self.getNeoData('"GET_TEMPLOG":["%s"]' % device)
+        if update:
+            self.logger.info("%s temp log: %s" % (device, json.dumps(update)))
+        else:
+            self.logger.error("%s get temp log command failed" % device)
+
     def changeIp(self, action):
         oldIP = self.neohubIP
         newIp = action.props.get("newIp", "")

--- a/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/plugin.py
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/plugin.py
@@ -583,7 +583,7 @@ class Plugin(indigo.PluginBase):
                     self.logger.info("--> %s" % cmdPhrase)
                 sock.send(cmdPhrase+b"\0")
                 dataj = sock.recv(4096)
-                while ((b"GET_LIVE_DATA" in cmdPhrase or b"INFO" in cmdPhrase) and (b"}]}" not in dataj[len(dataj)-5:len(dataj)-1])) or ((b"GET_ENGINEERS" in cmdPhrase or b"ENGINEERS_DATA" in cmdPhrase) and (b"}}" not in dataj[len(dataj)-4:len(dataj)-1])):
+                while ((b"GET_LIVE_DATA" in cmdPhrase or b"INFO" in cmdPhrase) and (b"}]}" not in dataj[len(dataj)-5:len(dataj)-1])) or ((b"GET_ENGINEERS" in cmdPhrase or b"ENGINEERS_DATA" in cmdPhrase or b"GET_HOURSRUN" in cmdPhrase or b"GET_TEMPLOG" in cmdPhrase) and (b"}}" not in dataj[len(dataj)-4:len(dataj)-1])):
                     chunk = sock.recv(4096)
                     if not chunk:
                         raise ConnectionError("NeoHub connection closed unexpectedly")
@@ -963,18 +963,18 @@ class Plugin(indigo.PluginBase):
     def getHoursRun(self, pluginAction):
         device = indigo.devices[pluginAction.deviceId].name
         update = self.getNeoData('"GET_HOURSRUN":"%s"' % device)
-        if update:
+        if isinstance(update, dict) and update:
             self.logger.info("%s hours run: %s" % (device, json.dumps(update)))
         else:
-            self.logger.error("%s get hours run command failed" % device)
+            self.logger.error("%s get hours run command failed (response: %r)" % (device, update))
 
     def getTempLog(self, pluginAction):
         device = indigo.devices[pluginAction.deviceId].name
         update = self.getNeoData('"GET_TEMPLOG":["%s"]' % device)
-        if update:
+        if isinstance(update, dict) and update:
             self.logger.info("%s temp log: %s" % (device, json.dumps(update)))
         else:
-            self.logger.error("%s get temp log command failed" % device)
+            self.logger.error("%s get temp log command failed (response: %r)" % (device, update))
 
     def changeIp(self, action):
         oldIP = self.neohubIP


### PR DESCRIPTION
## Summary
- Add `getHoursRun` action (wraps `GET_HOURSRUN`) — logs 7-day hours-on stats for a thermostat
- Add `getTempLog` action (wraps `GET_TEMPLOG`) — logs 7-day 15-min temperature readings
- Both reuse the existing `getNeoData()` transport (WSS + TCP fallback) and log JSON responses via `self.logger.info`
- No device state persistence this pass (log-only first cut)
- Bump PluginVersion to 2026.0.4

Closes the TempLog/HoursRun portion of #11. Remaining pieces of #11 (Away/Holiday/CancelHold/Lock/Boost) shipped in earlier versions; issue can be closed after this merges.

## Test plan
- [x] py_compile passes
- [x] Plugin restarts cleanly on jarvis as v2026.0.4 over WSS
- [ ] Trigger Get Hours Run on a thermostat and confirm response in Event Log
- [ ] Trigger Get Temp Log on a thermostat and confirm response in Event Log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Hours Run action to retrieve daily hours per device for the last 7 days
  * Added Temperature Log action to retrieve 15-minute interval temperature readings for the last 7 days
  * Results are logged to the Indigo Event Log

* **Chores**
  * Version bumped to 2026.0.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->