### PR TITLE
test: first-cut pytest suite (38 tests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 Heatmiser API docs.pdf
 Heatmiser-API-Reference.md
+.pytest_cache/
+__pycache__/
+*.pyc
+.coverage
+htmlcov/

--- a/HeatmiserNeo.IndigoPlugin/Contents/Info.plist
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2026.0.4</string>
+	<string>2026.0.5</string>
 	<key>ServerApiVersion</key>
 	<string>3.0</string>
 	<key>IwsApiVersion</key>

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = -v --tb=short

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,92 @@
+"""Shared fixtures and the `indigo` module stub.
+
+The heatmiser plugin `plugin.py` does `import indigo` and inherits from
+`indigo.PluginBase` at class-definition time, so we must inject a stub
+into `sys.modules` before any test imports the plugin module.
+"""
+import builtins
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# 1. Stub `indigo` module before plugin.py can import it
+class _HvacModeStub:
+    ProgramHeat = "ProgramHeat"
+    Heat = "Heat"
+    Cool = "Cool"
+    Off = "Off"
+
+
+indigo_stub = ModuleType("indigo")
+indigo_stub.PluginBase = object  # plugin.py does `class Plugin(indigo.PluginBase)`
+indigo_stub.kHvacMode = _HvacModeStub
+indigo_stub.devices = MagicMock()
+indigo_stub.variables = MagicMock()
+indigo_stub.variable = MagicMock()
+indigo_stub.server = MagicMock()
+sys.modules["indigo"] = indigo_stub
+# Indigo's runtime injects `indigo` as an implicit global; plugin.py never
+# does `import indigo`. Put it in builtins so the plugin module sees it.
+builtins.indigo = indigo_stub
+
+
+# 2. Add Server Plugin directory to sys.path so `import plugin` works
+SERVER_PLUGIN_DIR = (
+    Path(__file__).parent.parent
+    / "HeatmiserNeo.IndigoPlugin"
+    / "Contents"
+    / "Server Plugin"
+)
+sys.path.insert(0, str(SERVER_PLUGIN_DIR))
+
+
+@pytest.fixture
+def plugin():
+    """Construct a Plugin instance bypassing __init__.
+
+    Injects the minimum attributes the methods under test reference.
+    Tests patch `plugin.getNeoData` to a MagicMock to observe commands
+    or stub responses.
+    """
+    from plugin import Plugin
+
+    p = Plugin.__new__(Plugin)
+    p.logger = MagicMock()
+    p.neohubIP = "192.168.0.1"
+    p.neohubToken = "test-token"
+    p.connectionMode = "tcp"
+    p.logComms = False
+    p.commsEnabled = True
+    p.neohubGen2 = False
+    p.connectErrorCount = 0
+    p.sendErrorCount = 0
+    p.neoDevice = None
+    p.getNeoData = MagicMock(return_value={"result": "ok"})
+    return p
+
+
+@pytest.fixture
+def mock_device():
+    """A mock indigo device with a configurable name."""
+    dev = MagicMock()
+    dev.name = "TestStat"
+    dev.deviceTypeId = "heatmiserNeostat"
+    dev.id = 12345
+    return dev
+
+
+@pytest.fixture
+def action_for(mock_device):
+    """Factory that builds a plugin action bound to the mock device."""
+    def _make(**props):
+        action = MagicMock()
+        action.deviceId = mock_device.id
+        action.props = props
+        return action
+    # Wire indigo.devices[id] to return the mock device
+    indigo_stub.devices.__getitem__ = MagicMock(return_value=mock_device)
+    return _make

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,154 @@
+"""Action callback command-builder assertions.
+
+Each test patches `plugin.getNeoData` and asserts the exact `cmdPhrase`
+argument the callback builds. This catches regressions in API command
+syntax — e.g. scalar-vs-array device args, quoting, field order.
+"""
+
+
+def test_awayOn_builds_correct_command(plugin, action_for):
+    action = action_for()
+    plugin.awayOn(action)
+    plugin.getNeoData.assert_called_once_with('"AWAY_ON":["TestStat"]')
+
+
+def test_awayOff_builds_correct_command(plugin, action_for):
+    action = action_for()
+    plugin.awayOff(action)
+    plugin.getNeoData.assert_called_once_with('"AWAY_OFF":["TestStat"]')
+
+
+def test_cancelHold_builds_correct_command(plugin, action_for):
+    action = action_for()
+    plugin.cancelHold(action)
+    plugin.getNeoData.assert_called_once_with(
+        '"HOLD":[{"temp":20, "id":"Off", "hours":0, "minutes":0}, "TestStat"]'
+    )
+
+
+def test_unlockKeypad_builds_correct_command(plugin, action_for):
+    action = action_for()
+    plugin.unlockKeypad(action)
+    plugin.getNeoData.assert_called_once_with('"UNLOCK":["TestStat"]')
+
+
+def test_lockKeypad_splits_pin_into_digits(plugin, action_for):
+    action = action_for(lockPin="1234")
+    plugin.lockKeypad(action)
+    plugin.getNeoData.assert_called_once_with('"LOCK":[[1,2,3,4], ["TestStat"]]')
+
+
+def test_lockKeypad_defaults_to_0000(plugin, action_for):
+    action = action_for()
+    plugin.lockKeypad(action)
+    plugin.getNeoData.assert_called_once_with('"LOCK":[[0,0,0,0], ["TestStat"]]')
+
+
+def test_setFrostTemp_uses_configured_temp(plugin, action_for):
+    action = action_for(frostTemp="10")
+    plugin.setFrostTemp(action)
+    plugin.getNeoData.assert_called_once_with('"SET_FROST":[10, "TestStat"]')
+
+
+def test_identifyDevice_builds_correct_command(plugin, action_for):
+    action = action_for()
+    plugin.identifyDevice(action)
+    plugin.getNeoData.assert_called_once_with('"IDENTIFY":[1, 3, ["TestStat"]]')
+
+
+def test_timerBoost_uses_configured_minutes(plugin, action_for):
+    action = action_for(boostMinutes="60")
+    plugin.timerBoost(action)
+    plugin.getNeoData.assert_called_once_with('"TIMER_HOLD_ON":[60, "TestStat"]')
+
+
+def test_timerBoost_defaults_to_30min(plugin, action_for):
+    action = action_for()
+    plugin.timerBoost(action)
+    plugin.getNeoData.assert_called_once_with('"TIMER_HOLD_ON":[30, "TestStat"]')
+
+
+def test_timerBoostOff_sends_zero_minutes(plugin, action_for):
+    action = action_for()
+    plugin.timerBoostOff(action)
+    plugin.getNeoData.assert_called_once_with('"TIMER_HOLD_ON":[0, "TestStat"]')
+
+
+def test_setCool_builds_frost_on(plugin, action_for):
+    action = action_for()
+    plugin.setCool(action)
+    plugin.getNeoData.assert_called_once_with('"FROST_ON":["TestStat"]')
+
+
+def test_setCool_skips_unsupported_device_type(plugin, action_for, mock_device):
+    mock_device.deviceTypeId = "heatmiserNeoPlug"
+    action = action_for()
+    plugin.setCool(action)
+    plugin.getNeoData.assert_not_called()
+    plugin.logger.warning.assert_called_once()
+
+
+def test_setAuto_sends_frost_off_then_hold_off(plugin, action_for):
+    action = action_for()
+    plugin.setAuto(action)
+    assert plugin.getNeoData.call_count == 2
+    first_call = plugin.getNeoData.call_args_list[0].args[0]
+    second_call = plugin.getNeoData.call_args_list[1].args[0]
+    assert first_call == '"FROST_OFF":["TestStat"]'
+    assert second_call == (
+        '"HOLD":[{"temp":20, "id":"Off", "hours":0, "minutes":0}, "TestStat"]'
+    )
+
+
+def test_setOverride_full_hour(plugin, action_for):
+    action = action_for(overrideTemp="21", numberOfHours="02")
+    plugin.setOverride(action)
+    plugin.getNeoData.assert_called_once_with(
+        '"HOLD":[{"temp":21, "id":"Off", "hours":02, "minutes":0}, "TestStat"]'
+    )
+
+
+def test_setOverride_30min_splits_to_minutes(plugin, action_for):
+    action = action_for(overrideTemp="20", numberOfHours="0.5")
+    plugin.setOverride(action)
+    plugin.getNeoData.assert_called_once_with(
+        '"HOLD":[{"temp":20, "id":"Off", "hours":0, "minutes":30}, "TestStat"]'
+    )
+
+
+def test_cancelHoliday_builds_correct_command(plugin, action_for):
+    action = action_for()
+    plugin.cancelHoliday(action)
+    plugin.getNeoData.assert_called_once_with('"CANCEL_HOLIDAY":0')
+
+
+def test_getHoursRun_uses_scalar_device_arg(plugin, action_for):
+    """API docs example uses scalar form: {"GET_HOURSRUN":"Kitchen"}"""
+    plugin.getNeoData.return_value = {"day:1": {"TestStat": 5}}
+    action = action_for()
+    plugin.getHoursRun(action)
+    plugin.getNeoData.assert_called_once_with('"GET_HOURSRUN":"TestStat"')
+
+
+def test_getTempLog_uses_array_device_arg(plugin, action_for):
+    """API docs example uses array form: {"GET_TEMPLOG":["Kitchen"]}"""
+    plugin.getNeoData.return_value = {"day:1": {"TestStat": [20, 21]}}
+    action = action_for()
+    plugin.getTempLog(action)
+    plugin.getNeoData.assert_called_once_with('"GET_TEMPLOG":["TestStat"]')
+
+
+def test_getHoursRun_logs_error_on_empty_response(plugin, action_for):
+    plugin.getNeoData.return_value = ""
+    action = action_for()
+    plugin.getHoursRun(action)
+    plugin.logger.error.assert_called_once()
+    plugin.logger.info.assert_not_called()
+
+
+def test_getTempLog_logs_error_on_empty_response(plugin, action_for):
+    plugin.getNeoData.return_value = ""
+    action = action_for()
+    plugin.getTempLog(action)
+    plugin.logger.error.assert_called_once()
+    plugin.logger.info.assert_not_called()

--- a/tests/test_holiday.py
+++ b/tests/test_holiday.py
@@ -1,0 +1,59 @@
+"""setHoliday() date/time parsing edge cases.
+
+Covers the failure branches (invalid/missing date, invalid time, past
+date) and the success path. The success-path assertion ignores the
+runtime-dependent `now` portion of the HOLIDAY command and validates
+the deterministic end-time portion only.
+"""
+from unittest.mock import MagicMock
+
+
+def _action(**props):
+    a = MagicMock()
+    a.props = props
+    return a
+
+
+def test_missing_date_logs_error(plugin):
+    plugin.setHoliday(_action())
+    plugin.logger.error.assert_called_once()
+    plugin.getNeoData.assert_not_called()
+
+
+def test_invalid_date_format_logs_error(plugin):
+    plugin.setHoliday(_action(holidayEndDate="not-a-date"))
+    plugin.logger.error.assert_called_once()
+    plugin.getNeoData.assert_not_called()
+
+
+def test_invalid_time_format_logs_error(plugin):
+    plugin.setHoliday(_action(holidayEndDate="31/12/2099", holidayEndTime="bogus"))
+    plugin.logger.error.assert_called_once()
+    plugin.getNeoData.assert_not_called()
+
+
+def test_past_date_logs_error(plugin):
+    plugin.setHoliday(_action(holidayEndDate="01/01/2020", holidayEndTime="12:00"))
+    plugin.logger.error.assert_called_once()
+    assert "not in the future" in plugin.logger.error.call_args.args[0]
+    plugin.getNeoData.assert_not_called()
+
+
+def test_valid_future_date_builds_holiday_command(plugin):
+    plugin.setHoliday(_action(holidayEndDate="31/12/2099", holidayEndTime="14:30"))
+    plugin.getNeoData.assert_called_once()
+    cmd = plugin.getNeoData.call_args.args[0]
+    # Format is: "HOLIDAY":["<start>","<end>"] where end = HHMM00DDMMYYYY
+    assert cmd.startswith('"HOLIDAY":["')
+    assert '"143000311220 99"'.replace(" ", "") in cmd or "143000311220 99".replace(" ", "") in cmd
+    # Exact end-string check
+    assert ',"143000' in cmd  # HH=14 MM=30 SS=00
+    assert '31122099"]' in cmd  # DD=31 MM=12 YYYY=2099
+
+
+def test_dates_with_whitespace_are_trimmed(plugin):
+    plugin.setHoliday(_action(holidayEndDate="  31/12/2099  ", holidayEndTime=" 09:15 "))
+    plugin.getNeoData.assert_called_once()
+    cmd = plugin.getNeoData.call_args.args[0]
+    assert ',"091500' in cmd
+    assert '31122099"]' in cmd

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,123 @@
+"""TCP transport tests for `_get_neo_data_tcp`.
+
+Mocks `socket.socket` and feeds chunked `.recv()` responses to verify:
+- single-packet commands return parsed JSON
+- multi-packet responses for GET_LIVE_DATA / GET_ENGINEERS / GET_HOURSRUN /
+  GET_TEMPLOG assemble correctly until the terminator appears
+- `{"error": ...}` envelope returns "" and logs
+- non-printable bytes are filtered before JSON parse
+- the socket is closed even when send raises
+"""
+import socket
+from unittest.mock import MagicMock, patch
+
+
+def _make_fake_socket(chunks):
+    """Build a fake socket whose recv() returns the given byte chunks then b''."""
+    sock = MagicMock(spec=socket.socket)
+    sock.recv.side_effect = list(chunks) + [b""]
+    return sock
+
+
+def test_single_packet_command_parses_ok(plugin):
+    fake = _make_fake_socket([b'{"result":"ok"}'])
+    with patch("socket.socket", return_value=fake):
+        result = plugin._get_neo_data_tcp('"AWAY_ON":["X"]')
+    assert result == {"result": "ok"}
+    fake.close.assert_called_once()
+
+
+def test_get_live_data_assembles_multi_packet(plugin):
+    # Split a valid GET_LIVE_DATA response across three recv() calls.
+    # Terminator check looks at dataj[-5:-1], so we append a trailing null
+    # byte (matching what the real hub protocol sends).
+    full = b'{"devices":[{"name":"A"},{"name":"B"}]}\x00'
+    chunks = [full[:15], full[15:30], full[30:]]
+    fake = _make_fake_socket(chunks)
+    with patch("socket.socket", return_value=fake):
+        result = plugin._get_neo_data_tcp('"GET_LIVE_DATA":0')
+    assert result == {"devices": [{"name": "A"}, {"name": "B"}]}
+    assert fake.recv.call_count == 3
+
+
+def test_get_hoursrun_assembles_multi_packet(plugin):
+    """Regression test for the PR #22 TCP truncation fix."""
+    full = b'{"day:1":{"Kitchen":0},"today":{"Kitchen":12}}\x00'
+    chunks = [full[:20], full[20:]]
+    fake = _make_fake_socket(chunks)
+    with patch("socket.socket", return_value=fake):
+        result = plugin._get_neo_data_tcp('"GET_HOURSRUN":"Kitchen"')
+    assert result == {"day:1": {"Kitchen": 0}, "today": {"Kitchen": 12}}
+    assert fake.recv.call_count == 2
+
+
+def test_get_templog_assembles_multi_packet(plugin):
+    """Regression test for the PR #22 TCP truncation fix."""
+    full = b'{"day:1":{"Kitchen":[20,21]},"today":{"Kitchen":[22]}}\x00'
+    chunks = [full[:25], full[25:]]
+    fake = _make_fake_socket(chunks)
+    with patch("socket.socket", return_value=fake):
+        result = plugin._get_neo_data_tcp('"GET_TEMPLOG":["Kitchen"]')
+    assert "day:1" in result
+    assert fake.recv.call_count == 2
+
+
+def test_get_engineers_assembles_multi_packet(plugin):
+    full = b'{"StatA":{"RATE OF CHANGE":5}}\x00'
+    chunks = [full[:12], full[12:]]
+    fake = _make_fake_socket(chunks)
+    with patch("socket.socket", return_value=fake):
+        result = plugin._get_neo_data_tcp('"GET_ENGINEERS":0')
+    assert result == {"StatA": {"RATE OF CHANGE": 5}}
+
+
+def test_error_envelope_returns_empty_string(plugin):
+    fake = _make_fake_socket([b'{"error":"bad command"}'])
+    with patch("socket.socket", return_value=fake):
+        result = plugin._get_neo_data_tcp('"BOGUS":0')
+    assert result == ""
+    plugin.logger.error.assert_called()
+
+
+def test_non_printable_bytes_are_filtered(plugin):
+    fake = _make_fake_socket([b'\x00\x01{"result":"ok"}\xff'])
+    with patch("socket.socket", return_value=fake):
+        result = plugin._get_neo_data_tcp('"AWAY_ON":["X"]')
+    assert result == {"result": "ok"}
+
+
+def test_socket_closed_on_send_exception(plugin):
+    fake = _make_fake_socket([b''])
+    fake.send.side_effect = socket.error("boom")
+    with patch("socket.socket", return_value=fake):
+        result = plugin._get_neo_data_tcp('"AWAY_ON":["X"]')
+    assert result == ""
+    fake.close.assert_called_once()
+
+
+def test_socket_closed_on_connect_exception(plugin):
+    fake = MagicMock(spec=socket.socket)
+    fake.connect.side_effect = socket.timeout("timeout")
+    with patch("socket.socket", return_value=fake):
+        result = plugin._get_neo_data_tcp('"AWAY_ON":["X"]')
+    assert result == ""
+    fake.close.assert_called_once()
+
+
+def test_comms_disabled_short_circuits(plugin):
+    plugin.commsEnabled = False
+    from plugin import Plugin
+    # Fixture mocks getNeoData; call the real method via the class
+    assert Plugin.getNeoData(plugin, '"AWAY_ON":["X"]') == ""
+
+
+def test_getNeoData_routes_to_tcp_when_mode_tcp(plugin):
+    plugin.connectionMode = "tcp"
+    plugin._get_neo_data_tcp = MagicMock(return_value={"ok": True})
+    plugin._get_neo_data_wss = MagicMock()
+    # Re-bind getNeoData from the class since the fixture mocks it
+    from plugin import Plugin
+    result = Plugin.getNeoData(plugin, '"AWAY_ON":["X"]')
+    assert result == {"ok": True}
+    plugin._get_neo_data_tcp.assert_called_once()
+    plugin._get_neo_data_wss.assert_not_called()


### PR DESCRIPTION
## Summary
- **38 tests** across three modules — actions (21), TCP transport (11), holiday parsing (6)
- Runs without Indigo runtime via a \`conftest.py\` that stubs the \`indigo\` module into \`builtins\` (plugin.py relies on Indigo's loader injecting \`indigo\` as an implicit global)
- Pattern copied from \`netro/tests/\`

## What's covered
- Every action callback asserts the exact command string passed to \`getNeoData()\` — would have caught the \`GET_HOURSRUN\` scalar-vs-array concern from #22 review
- TCP multi-packet terminator loop for \`GET_LIVE_DATA\` / \`GET_ENGINEERS\` / \`GET_HOURSRUN\` / \`GET_TEMPLOG\` — direct regression test for the PR #22 truncation fix
- Error envelope handling, non-printable byte filtering, socket cleanup on exception
- \`setHoliday\` date/time parsing edge cases (invalid formats, past dates, whitespace trim)

## Out of scope (follow-up)
- WSS transport tests (async websockets library, harder to mock — defer until it hurts)
- \`updateStatState\` field extraction (needs Gen 1/Gen 2 fixture data)
- CI integration (local-only for now, will wire GitHub Actions in a separate PR)

## Running
\`\`\`bash
cd heatmiser
pytest
\`\`\`

Version bumped to 2026.0.5 for CI version-check.

## Test plan
- [x] All 38 tests pass locally
- [x] Plugin unchanged (no behavior risk)
- [x] CI version-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)