### PR TITLE
fix: close WSS on IP change in changeIp and discoverNeohub

### DIFF
--- a/HeatmiserNeo.IndigoPlugin/Contents/Info.plist
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2026.0.5</string>
+	<string>2026.0.6</string>
 	<key>ServerApiVersion</key>
 	<string>3.0</string>
 	<key>IwsApiVersion</key>

--- a/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/plugin.py
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/plugin.py
@@ -760,9 +760,12 @@ class Plugin(indigo.PluginBase):
             foundIp = response.get("ip", "")
             deviceId = response.get("device_id", "").strip()
             if foundIp:
+                ipChanged = foundIp != self.neohubIP
                 self.neohubIP = foundIp
                 self.pluginPrefs["neohubIP"] = foundIp
                 self.savePluginPrefs()
+                if ipChanged:
+                    self._close_wss()
                 self.logger.info("NeoHub found at %s (device: %s)" % (foundIp, deviceId))
             else:
                 self.logger.warning("NeoHub responded but no IP in response")
@@ -982,6 +985,7 @@ class Plugin(indigo.PluginBase):
         if newIp != "":
             self.neohubIP = newIp
             if self.neohubIP != oldIP:
+                self._close_wss()
                 self.logger.info("Neohub IP address is now %s" % self.neohubIP)
         else:
             self.logger.error("Invalid IP address supplied")

--- a/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/plugin.py
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/plugin.py
@@ -761,11 +761,15 @@ class Plugin(indigo.PluginBase):
             deviceId = response.get("device_id", "").strip()
             if foundIp:
                 ipChanged = foundIp != self.neohubIP
-                self.neohubIP = foundIp
-                self.pluginPrefs["neohubIP"] = foundIp
-                self.savePluginPrefs()
+                # Close the persistent WSS first, then swap in the new IP.
+                # Doing it in the opposite order leaves a brief window in
+                # which another thread could dispatch a command against
+                # the new IP while the old socket is still being torn down.
                 if ipChanged:
                     self._close_wss()
+                    self.neohubIP = foundIp
+                    self.pluginPrefs["neohubIP"] = foundIp
+                    self.savePluginPrefs()
                 self.logger.info("NeoHub found at %s (device: %s)" % (foundIp, deviceId))
             else:
                 self.logger.warning("NeoHub responded but no IP in response")
@@ -982,13 +986,15 @@ class Plugin(indigo.PluginBase):
     def changeIp(self, action):
         oldIP = self.neohubIP
         newIp = action.props.get("newIp", "")
-        if newIp != "":
-            self.neohubIP = newIp
-            if self.neohubIP != oldIP:
-                self._close_wss()
-                self.logger.info("Neohub IP address is now %s" % self.neohubIP)
-        else:
+        if newIp == "":
             self.logger.error("Invalid IP address supplied")
+            return
+        if newIp != oldIP:
+            # Close-before-mutate: tear down the old socket first so a
+            # concurrent command can't land on the new IP mid-teardown.
+            self._close_wss()
+            self.neohubIP = newIp
+            self.logger.info("Neohub IP address is now %s" % self.neohubIP)
                 
 
 


### PR DESCRIPTION
## Summary

- `changeIp()` (action) and `discoverNeohub()` (hubseek) updated `self.neohubIP` without closing the persistent WSS connection. After an IP change, the plugin kept talking to the old IP until the old connection eventually errored out.
- `closedPrefsConfigUi` already closes the WSS when the IP changes in prefs — this PR mirrors that behavior into the two paths that were missing it.
- Bumped `PluginVersion` to `2026.0.6`.

## Test plan

- [ ] Deploy to jarvis.local and restart plugin
- [ ] Run Change IP action with same IP → no reconnect, no errors
- [ ] Run Change IP action with a different IP → log shows IP change, next poll reconnects to new host
- [ ] Run hubseek (discoverNeohub) → same outcome if a new IP is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved handling of NeoHub IP address changes—existing connections are now properly closed when the IP is updated, preventing potential connection issues during network reconfiguration.

* **Chores**
  * Version updated to 2026.0.6

<!-- end of auto-generated comment: release notes by coderabbit.ai -->