### PR TITLE
chore: declare websockets as an explicit requirement

### DIFF
--- a/HeatmiserNeo.IndigoPlugin/Contents/Info.plist
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2026.0.8</string>
+	<string>2026.0.9</string>
 	<key>ServerApiVersion</key>
 	<string>3.0</string>
 	<key>IwsApiVersion</key>

--- a/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/requirements.txt
+++ b/HeatmiserNeo.IndigoPlugin/Contents/Server Plugin/requirements.txt
@@ -1,0 +1,1 @@
+websockets>=12.0          # plugin.py imports websockets.sync.client (sync API stable from 12.0+)


### PR DESCRIPTION
## Summary

Adds a `requirements.txt` to the plugin bundle declaring its dependency
on `websockets`. Bumps `PluginVersion` 2026.0.8 → 2026.0.9.

## Why

`plugin.py:18` imports `websockets.sync.client` for the WSS path
(port 4243 + token auth). Until now the dep was undeclared — the
plugin relied on whatever happened to be in Indigo's Python environment
from prior installs or transitive installs by other plugins. Discovered
during a workspace-wide post-2025.2 audit: this is a contract gap, not
a current break (jarvis happens to have it from earlier installs).

With this `requirements.txt`, Indigo's auto-installer guarantees the dep
on fresh installs / re-imaging / new dev machines, so WSS mode won't
silently fall back to TCP.

## Pin choice

`websockets>=12.0` — the sync client API arrived in 11.0 and stabilized
in 12.x. Current 15.x continues to satisfy. No upper bound: the per-call
connection design merged in PR #27 is robust to future library versions.

## Test plan

- [x] pytest: 38/38 pass under Python 3.13.9
- [ ] Deploy to jarvis (auto-install kicks in on plugin restart)
- [ ] Confirm `Started plugin "Heatmiser-Neo 2026.0.9"` followed by
      `Using WSS connection (port 4243)` (not the TCP fallback)
- [ ] Verify `GET_LIVE_DATA` round-trips still working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2026.0.9
  * Added websockets library dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->